### PR TITLE
Initial naive windows support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 
 [dependencies]
 libc = "0.2.2"
+winapi = "0.2"
+kernel32-sys = "0.2"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 
 [dependencies]
 libc = "0.2.2"
+
+[target.x86_64-pc-windows-gnu.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
 
+[target.i686-pc-windows-gnu.dependencies]
+winapi = "0.2"
+kernel32-sys = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod memory {
     }
 
     pub unsafe fn make_executable(addr: *mut libc::c_void, size: libc::size_t) {
-        let mut _previous_protect : *mut u32 = &mut 0u32 as *mut u32;
+        let mut _previous_protect : *mut u32 = ::std::mem::uninitialized();
         kernel32::VirtualProtect(addr as *mut ::std::os::raw::c_void, size as u64, 
             winapi::winnt::PAGE_EXECUTE_READWRITE, _previous_protect as u32);
     }
@@ -33,7 +33,7 @@ mod memory {
     extern crate libc;
 
     pub unsafe fn aligned_malloc(size: libc::size_t, alignment: libc::size_t) -> *mut libc::c_void {
-        let mut _contents : *mut libc::c_void = ::std::ptr::null_mut();
+        let mut _contents : *mut libc::c_void = ::std::mem::uninitialized();
         libc::posix_memalign(&mut _contents, alignment, size);
 
         _contents


### PR DESCRIPTION
This is not really meant to be merged - especially not in this state. I'm just submitting this PR to make it easier for people to find and perhaps start a brief discussion.

Since this is just short example code to accompany your blog entry, It'd make sense if you just wanted to leave it as is. Adding cross-platform support is clutter which doesn't help much when learning. However, if you're interested, I'd be happy to submit a version that uses `#[cfg()]` directives to work on both unix and windows.
